### PR TITLE
chore: add cd.yaml to publish to npm and github registry

### DIFF
--- a/.github/cd.yaml
+++ b/.github/cd.yaml
@@ -1,0 +1,107 @@
+name: Deploy to NPM and GitHub Package Registry
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GTP_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - name: Create empty .env file
+        run: touch .env
+      - run: npm test
+      - run: npm run build
+      - name: Publish to NPM
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+
+          # Read version from package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Current package version: $VERSION"
+
+          # Check if version already exists on npm
+          NPM_VIEW_OUTPUT=$(npm view @firefliesai/fireflies-node-sdk@$VERSION 2>&1 || true)
+          if [[ $NPM_VIEW_OUTPUT != *"E404"* && $NPM_VIEW_OUTPUT != *"npm ERR! code E404"* ]]; then
+            echo "Version $VERSION already exists on npm registry. Skipping npm publish."
+            SKIP_NPM_PUBLISH="true"
+          else
+            echo "Version $VERSION does not exist on npm registry. Proceeding with publish."
+            SKIP_NPM_PUBLISH="false"
+          fi
+
+          # Only publish if version doesn't already exist
+          if [[ "$SKIP_NPM_PUBLISH" == "false" ]]; then
+            # Check if version contains prerelease marker (e.g., -rc, -beta, -alpha)
+            if [[ $VERSION == *"-"* ]]; then
+              # Extract prerelease tag (e.g., extract 'rc' from '1.0.0-rc.1')
+              PRERELEASE_TAG=$(echo $VERSION | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z]+).*/\1/')
+              echo "Detected prerelease version with tag: $PRERELEASE_TAG"
+
+              # Publish with the extracted tag
+              npm publish --tag $PRERELEASE_TAG --access public
+
+              echo "Published with tag: $PRERELEASE_TAG"
+            else
+              # Regular version, publish with default tag (latest)
+              npm publish --access public
+
+              echo "Published as latest version"
+            fi
+          fi
+
+          # Set output for GitHub Package Registry step
+          echo "SKIP_NPM_PUBLISH=${SKIP_NPM_PUBLISH}" >> $GITHUB_ENV
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create .npmrc file for GitHub Package Registry
+        run: |
+          rm -f .npmrc
+          echo "@firefliesai:registry=https://npm.pkg.github.com" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GTP_TOKEN}" >> .npmrc
+          
+      - name: Publish Package to GitHub Package Registry
+        run: |
+          # Read version from package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Current package version: $VERSION"
+          
+          # Check if version already exists on GitHub Package Registry
+          # Use 2>&1 to capture stderr, and || true to prevent the script from failing if the package doesn't exist
+          GH_VIEW_OUTPUT=$(npm view @firefliesai/fireflies-node-sdk@$VERSION --registry=https://npm.pkg.github.com/ 2>&1 || true)
+          
+          if [[ $GH_VIEW_OUTPUT != *"E404"* && $GH_VIEW_OUTPUT != *"npm ERR! code E404"* ]]; then
+            echo "Version $VERSION already exists on GitHub Package Registry. Skipping publish."
+          else
+            echo "Version $VERSION does not exist on GitHub Package Registry. Proceeding with publish."
+            
+            # Check if version contains prerelease marker (e.g., -rc, -beta, -alpha)
+            if [[ $VERSION == *"-"* ]]; then
+              # Extract prerelease tag (e.g., extract 'rc' from '1.0.0-rc.1')
+              PRERELEASE_TAG=$(echo $VERSION | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z]+).*/\1/')
+              echo "Detected prerelease version with tag: $PRERELEASE_TAG"
+              
+              # Publish with the extracted tag
+              npm publish --tag $PRERELEASE_TAG --access public --registry=https://npm.pkg.github.com/
+              
+              echo "Published to GitHub Package Registry with tag: $PRERELEASE_TAG"
+            else
+              # Regular version, publish with default tag (latest)
+              npm publish --access public --registry=https://npm.pkg.github.com/
+              
+              echo "Published to GitHub Package Registry as latest version"
+            fi
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

This is copied from https://github.com/firefliesai/schema-forge/blob/develop/.github/workflows/cd.yml, and welcome to improve this. Currently, the benefit of adding this is we can manually trigger the workflow_dispatch to release, at least. The left todo is to add `NPM_TOKEN` in this repo setting. @sleemkeen @MrMuhammadAbdullah1704 @greguintow could you help to add this (as the screenshot below)? 

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?


<img width="1325" alt="截圖 2025-05-05 18 45 55" src="https://github.com/user-attachments/assets/e064ec0d-aff5-4bb8-b947-10306fedfb97" />


## Screenshots (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added automated deployment workflow for publishing packages to NPM and GitHub Package Registry, including support for prerelease tags and version checks to prevent duplicate publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->